### PR TITLE
chore: enable voip and audio background modes

### DIFF
--- a/Telnyx Meet/Info.plist
+++ b/Telnyx Meet/Info.plist
@@ -21,6 +21,11 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>apiKey</key>
 	<string>YOUR_API_KEY</string>
 	<key>apiUrl</key>


### PR DESCRIPTION
In order to keep the app running in background we are adding the background modes:
- VoIP Services
- Audio, AirPlay and Picture in Picture