### PR TITLE
fix: duplicate participant tiles

### DIFF
--- a/Telnyx Meet/Views/VideoMeetParticipantCell.swift
+++ b/Telnyx Meet/Views/VideoMeetParticipantCell.swift
@@ -97,10 +97,18 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         self.audioCensoredView.isHidden = !isAudioCensored
     }
 
-    override func prepareForReuse() {
+    private func stopRendering() {
         if var renderer = videoRendererView as? VideoRenderer {
             renderer.videoTrack = nil
         }
+    }
+
+    override func prepareForReuse() {
+        stopRendering()
         super.prepareForReuse()
+    }
+
+    deinit {
+        stopRendering()
     }
 }

--- a/Telnyx Meet/Views/VideoMeetParticipantCell.swift
+++ b/Telnyx Meet/Views/VideoMeetParticipantCell.swift
@@ -11,7 +11,9 @@ class VideoMeetParticipantCell : UICollectionViewCell {
     @IBOutlet private weak var microphoneView: UIImageView!
     @IBOutlet private weak var audioCensoredView: UIImageView!
 
-    private lazy var videoRendererView: UIView = {
+    private var videoRendererView: UIView?
+
+    private func createVideoRendererView() -> UIView {
         #if arch(arm64)
         let renderer = MTLVideoView()
         renderer.videoContentMode = .scaleAspectFit
@@ -19,15 +21,17 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         #else
         return GLVideoView()
         #endif
-    }()
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        addVideoRendererView()
     }
 
     private func addVideoRendererView() {
-        if videoRendererView.superview != nil { return } // Already added.
+        // Cleanup previous video renderer view
+        for view in streamingView.subviews {
+            view.removeFromSuperview()
+        }
+
+        // Create a new video renderer view
+        let videoRendererView = createVideoRendererView()
+        self.videoRendererView = videoRendererView
 
         streamingView.addSubview(videoRendererView)
         videoRendererView.translatesAutoresizingMaskIntoConstraints = false
@@ -41,9 +45,7 @@ class VideoMeetParticipantCell : UICollectionViewCell {
     }
 
     private func startRenderingVideo(videoTrack: RTCVideoTrack?) {
-        if videoRendererView.superview == nil {
-            addVideoRendererView()
-        }
+        addVideoRendererView()
         if var renderer = videoRendererView as? VideoRenderer {
             renderer.videoTrack = videoTrack
         }
@@ -101,6 +103,8 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         if var renderer = videoRendererView as? VideoRenderer {
             renderer.videoTrack = nil
         }
+        videoRendererView?.removeFromSuperview()
+        videoRendererView = nil
     }
 
     override func prepareForReuse() {


### PR DESCRIPTION
**Issue:**
When a screen sharing participant leaves a room, we see duplicate participant tiles.

**Cause:**
This issue occurred because whenever there is an update in the screen share, we reload the collection view and the cells are reused/recreated resulting in duplicate tiles.
We are also reloading specific participant cells whenever we get participant update events like mute/unmute event, video on/off, etc.

**Fixes:**
- We are now updating the UI for the participant without reloading the cells.
- We check for the participant cell and set the data as we do in `collectionView.cellForItemAtIndexPath`.
- Cleanup video renderer views when the cell is reused/deinitialized