### PR TITLE
fix: freeze when subscribing to video

### DIFF
--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -590,7 +590,7 @@ class VideoMeetRoomViewController: UIViewController {
                                          audio: Bool,
                                          video: Bool,
                                          completion: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             self.room.addSubscription(participantId: participantId, key: key, audio: audio, video: video) {
                 completion()
             }

--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -543,7 +543,7 @@ class VideoMeetRoomViewController: UIViewController {
         }
     }
 
-    /// This function publishes local stream if all the subscriptions for visible participants is ocmpleted.
+    /// This function publishes local stream if all the subscriptions for visible participants are ocmpleted.
     /// Local stream is also oublished If there are no remote participants or no remote participants are sharing video.
     private func publishIfSubscriptionsCompleted() {
         if self.localStream != nil {
@@ -570,7 +570,7 @@ class VideoMeetRoomViewController: UIViewController {
         }
 
         if subscriptionsCompleted == totalVideoStreams {
-            // All the subscriptions for visible participants is completed.
+            // All the subscriptions for visible participants are completed.
             self.publishLocalStream(audio: true, video: true)
         }
     }

--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -59,6 +59,8 @@ class VideoMeetRoomViewController: UIViewController {
             }
         }
     }
+    /// This map is used to keep a track of subscription status for visible participant's streams.
+    private var visibleParticipantsSubscriptions = [ParticipantId: [StreamKey: Bool]]()
 
     // MARK: - IBOutlets
 
@@ -310,6 +312,8 @@ class VideoMeetRoomViewController: UIViewController {
             }
             if self.visibleParticipants.count < self.maxVisibleParticipants {
                 self.visibleParticipants.append(participantId)
+                // We need to keep a track of subscriptions for visible participants.
+                self.visibleParticipantsSubscriptions[participantId] = [:]
             }
             self.participantJoined(participantId: participantId)
         }
@@ -405,6 +409,10 @@ class VideoMeetRoomViewController: UIViewController {
             } else {
                 self.updateParticipant(participantId: participantId)
             }
+
+            // Update subscription status for subscription
+            self.visibleParticipantsSubscriptions[participantId]?[streamKey] = true
+            self.publishIfSubscriptionsCompleted()
         }
 
         room.onSubscriptionPaused = { [weak self] participantId, streamKey in
@@ -477,7 +485,7 @@ class VideoMeetRoomViewController: UIViewController {
                     self.participantsColletionView.reloadData()
                     self.updateAllParticipantsUI()
                 }
-                self.publishLocalStream(audio: true, video: true)
+                self.publishIfSubscriptionsCompleted()
             }
         }
     }
@@ -535,25 +543,61 @@ class VideoMeetRoomViewController: UIViewController {
         }
     }
 
+    /// This function publishes local stream if all the subscriptions for visible participants is ocmpleted.
+    /// Local stream is also oublished If there are no remote participants or no remote participants are sharing video.
+    private func publishIfSubscriptionsCompleted() {
+        if self.localStream != nil {
+            // Already published local stream.
+            return
+        }
+
+        let totalParticipants = self.room.state.participants.count
+        let totalVideoStreams = self.room.state.participants.reduce(0) { result, pair in
+            return result + pair.value.streams.count
+        }
+
+        if totalParticipants == 1 || totalVideoStreams == 0 {
+            // There are no participants or no remote participant is sharing their video.
+            self.publishLocalStream(audio: true, video: true)
+            return
+        }
+
+        // There are remote participants with video on.
+        // Wait till all the subscriptions for only the visible participants is completed.
+        let subscriptionsCompleted = self.visibleParticipantsSubscriptions.reduce(0) { result, item in
+            let subscriptions = item.value.filter({ $0.value == true }).count
+            return result + subscriptions
+        }
+
+        if subscriptionsCompleted == totalVideoStreams {
+            // All the subscriptions for visible participants is completed.
+            self.publishLocalStream(audio: true, video: true)
+        }
+    }
+
     private func publishLocalStream(audio: Bool, video: Bool) {
-        mediaDevices.simulatorVideoFileName = "telnyx.mp4"
-        self.mediaDevices.getUserMedia(audio: true, video: true, cameraPosition: .front, onSuccess: { mediaStream in
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
 
-            self.localStream = mediaStream
-            let audioTrack = audio ? self.localStream?.audioTracks.first : nil
-            let videoTrack = video ? self.localStream?.videoTracks.first : nil
+            self.mediaDevices.simulatorVideoFileName = "telnyx.mp4"
+            self.mediaDevices.getUserMedia(audio: true, video: true, cameraPosition: .front, onSuccess: { mediaStream in
 
-            self.room.addStream(key: "self", audio: audioTrack, video: videoTrack) { [weak self] in
-                guard let self = self else { return }
-                self.audioEnabled = audio
-                self.videoEnabled = video
-                self.updateMicButton()
-                self.updateCameraButton()
-                self.updateParticipant(participantId: self.localParticipantId)
-            }
-        }, onFailed: { error in
-            // handle error
-        })
+                self.localStream = mediaStream
+                let audioTrack = audio ? self.localStream?.audioTracks.first : nil
+                let videoTrack = video ? self.localStream?.videoTracks.first : nil
+
+                self.room.addStream(key: "self", audio: audioTrack, video: videoTrack) { [weak self] in
+                    guard let self = self else { return }
+                    self.audioEnabled = audio
+                    self.videoEnabled = video
+                    self.updateMicButton()
+                    self.updateCameraButton()
+                    self.updateParticipant(participantId: self.localParticipantId)
+                }
+            }, onFailed: { error in
+                // handle error
+            })
+        }
     }
 
     private func updateLocalStream(audio: Bool, video: Bool) {
@@ -590,7 +634,9 @@ class VideoMeetRoomViewController: UIViewController {
                                          audio: Bool,
                                          video: Bool,
                                          completion: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+        // Keep a track of subscription
+        self.visibleParticipantsSubscriptions[participantId]?[key] = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.room.addSubscription(participantId: participantId, key: key, audio: audio, video: video) {
                 completion()
             }


### PR DESCRIPTION
**Issue:**
When you join a room with at least 8 participants in a room all sharing video, the UI freezes when subscribing to all the participants video streams.
This is experienced on iPhone 12.

**Cause:**
This is because when you join a room, there are a lot of incoming messages from the server. There is a lot of message handling and subscribing to video streams happening on the app. At the same time we are publishing local stream.
Publishing local stream consumes more cpu as it invokes the camera, starts capturing frames and at the same time publish the local video.
When we join a room, we need the cpu to process all the janus messages and complete the subscriptions. After this, we can publish local video.

**Solution:**
Publishing local stream when all the subscriptions for visible participants are completed.