### PR TITLE
fix: Avoid an app crash when multiple participants leave the room at the same time

### DIFF
--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -549,7 +549,7 @@ class VideoMeetRoomViewController: UIViewController {
     }
     
     private func showLoading() {
-        self.participantsColletionView.isHidden = true        
+        self.participantsColletionView.isHidden = true
         let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
         loadingIndicator.hidesWhenStopped = true
         loadingIndicator.style = UIActivityIndicatorView.Style.medium
@@ -633,7 +633,7 @@ class VideoMeetRoomViewController: UIViewController {
 
         if totalParticipants == 1 || totalVideoStreams == 0 {
             // There are no participants or no remote participant is sharing their video.
-            self.publishLocalStream(audio: false, video: false)
+            self.publishLocalStream(audio: true, video: true)
             return
         }
 

--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -395,7 +395,6 @@ class VideoMeetRoomViewController: UIViewController {
 
         room.onParticipantLeft = { [weak self] participantId in
             guard let self = self else { return }
-            self.visibleParticipants.removeAll(where: { $0 == participantId })
             self.participantLeft(participantId: participantId)
         }
 
@@ -728,6 +727,7 @@ class VideoMeetRoomViewController: UIViewController {
 
     private func participantLeft(participantId: String) {
         DispatchQueue.main.async {
+            self.visibleParticipants.removeAll(where: { $0 == participantId })
             if self.isScreenShareOn, self.participantScreenSharing?.id == participantId {
                 self.participantScreenSharing = nil
                 self.updateScreenShareView()

--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -657,7 +657,8 @@ class VideoMeetRoomViewController: UIViewController {
     }
 
     private func updateLocalStream(audio: Bool, video: Bool) {
-        if ((try? room.getLocalStreams()) != nil) {
+        if let localStreams = try? room.getLocalStreams(),
+           localStreams.count != 0 {
             let audioTrack = audio ? localStream?.audioTracks.first : nil
             let videoTrack = video ? localStream?.videoTracks.first : nil
             


### PR DESCRIPTION
This PR contains the following changes:
- Add a loading view until the Joining process is completed.
- Modify the visibleParticipant array inside the main queue when a participant left the room.
- Allow the participant to toggle video and audio