### PR TITLE
chore: update specific UI instead of reloading entire participant view

### DIFF
--- a/Telnyx Meet/Views/VideoMeetParticipantCell.swift
+++ b/Telnyx Meet/Views/VideoMeetParticipantCell.swift
@@ -44,23 +44,22 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         streamingView.layoutIfNeeded()
     }
 
-    private func startRenderingVideo(videoTrack: RTCVideoTrack?) {
+    func startRenderingVideo(videoTrack: RTCVideoTrack?) {
         addVideoRendererView()
         if var renderer = videoRendererView as? VideoRenderer {
             renderer.videoTrack = videoTrack
         }
     }
 
-    private func setMicrophoneActive(isAudioEnabled: Bool) {
+    func setMicrophoneActive(isAudioEnabled: Bool) {
         self.microphoneView.isHidden = isAudioEnabled
     }
 
-    private func setVideoActive(isVideoActive: Bool) {
+    func setVideoActive(isVideoActive: Bool) {
         if !isVideoActive {
-            for view in self.streamingView.subviews {
-                view.removeFromSuperview()
-            }
+            stopRendering()
         }
+        streamingView.isHidden = !isVideoActive
         bigUserName.isHidden = isVideoActive
         userName.isHidden = !isVideoActive
     }
@@ -77,6 +76,7 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         setMicrophoneActive(isAudioEnabled: stream?.isAudioEnabled ?? false)
         setAudioCensored(isAudioCensored: stream?.isAudioCensored ?? false)
     }
+
 
     func flipCamera(mirror: Bool) {
         self.streamingView.transform = mirror ? CGAffineTransform(scaleX: -1, y: 1) : CGAffineTransform.identity
@@ -95,7 +95,7 @@ class VideoMeetParticipantCell : UICollectionViewCell {
         }
     }
     
-    private func setAudioCensored(isAudioCensored: Bool) {
+    func setAudioCensored(isAudioCensored: Bool) {
         self.audioCensoredView.isHidden = !isAudioCensored
     }
 


### PR DESCRIPTION
**Before:**
Earlier, if we receive mute / unmute event for a remote participant, we used to reload the entire participant view.
This used to cause the video view to be removed and re-add a new video view and start rendering video.

**After:**
We are updating only the specific UI.
If we get mute/unmute event, we only update the mic icon.
If we get video on/off event, we only update the video view.

**Below is the example that shows how the UI update looks like when a remote participant mutes/unmutes their microphone.**

| Before | After |
| --- | --- |
| UI update is not smooth | UI update is smooth |
| ![update-ui-issue](https://user-images.githubusercontent.com/14951672/172905775-04bd3f09-72a2-4064-b555-7273e2ae55b1.gif) | ![update-ui-fixed](https://user-images.githubusercontent.com/14951672/172905809-f4bf2ce3-7fcc-4082-a676-2cab30a81920.gif) |