### PR TITLE
feat: select audio output devices

### DIFF
--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import TelnyxVideoSdk
 import WebRTC
+import MediaPlayer
 
 class VideoMeetRoomViewController: UIViewController {
 
@@ -63,6 +64,31 @@ class VideoMeetRoomViewController: UIViewController {
     private var visibleParticipantsSubscriptions = [ParticipantId: [StreamKey: Bool]]()
 
     private var loadingView: UIAlertController = UIAlertController(title: nil, message: "Joining...", preferredStyle: .alert)
+
+    /// Checks if there is any external audio output device like AitPods / bluetooth / wired headphones connected.
+    var isUsingExternalAudioOutput: Bool {
+        get {
+            let outputs = audioSession.currentRoute.outputs
+            for portDesc in outputs {
+                if portDesc.portType != .builtInSpeaker &&
+                    portDesc.portType != .builtInReceiver {
+                    // Audio is routed via some external audio output device
+                    // e.g: AirPods / wired headphones
+                    return true
+                }
+            }
+            // no external audio output devices found
+            return false
+        }
+    }
+    /// Boolean property to toggle audio output to and from speaker
+    var isSpeaker = true {
+        didSet {
+            try? audioSession.overrideOutputAudioPort(isSpeaker ? .speaker : .none)
+        }
+    }
+    private let audioSession = AVAudioSession.sharedInstance()
+
     // MARK: - IBOutlets
 
     @IBOutlet private weak var participantsColletionView: UICollectionView!
@@ -101,6 +127,64 @@ class VideoMeetRoomViewController: UIViewController {
         updateCollectionViewLayout()
     }
 
+    private func configureAudio() {
+        NotificationCenter.default.addObserver(self, selector: #selector(audioRouteChanged(notification:)), name: AVAudioSession.routeChangeNotification, object: nil)
+
+        try? audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker, .allowBluetooth, .allowBluetoothA2DP])
+        try? audioSession.setMode(.videoChat)
+        try? audioSession.setActive(true)
+
+        #if !targetEnvironment(simulator)
+        // Configure audio output devices menu
+        /**
+         It is complex/difficult to change the output devices.
+         This is a hack to present the audio output devices.
+
+         To achieve this, we are using `MPVolumeView` from `MediaPlayer` module.
+         `MPVolumeView` shows volume slider and `MPButton` (part of private API).
+         We only need `MPButton` so we disable/hide the volume slider.
+         The click event of the `MPButton` is handled by the system/MediaPlayer internally.
+         The system then takes care of presenting available output devices.
+
+         `Please note that this is not the recommended way of selecting audio routes.`
+         `This is just a sample app so we are using this hack.`
+         */
+        let audioOutptView = MPVolumeView()
+        audioOutptView.showsVolumeSlider = false // disable the volume slider
+        for subView in audioOutptView.subviews {
+            if let audioRouteBtn = subView as? UIButton {
+                // set custom icon and tint color for `MPButton`
+                // by default, it shows the air play icon in white color and we are not able to tint that image.
+                audioRouteBtn.setImage(UIImage(systemName: "airplayvideo")?.withRenderingMode(.alwaysTemplate), for: .normal)
+                audioRouteBtn.tintColor = .txGreen
+            }
+        }
+
+        let barButton = UIBarButtonItem(customView: audioOutptView)
+        self.navigationItem.rightBarButtonItems?.append(barButton)
+        #endif
+
+        if !isUsingExternalAudioOutput {
+            // if not using AirPods / Headphones
+            // we override the audio output to speaker
+            isSpeaker = true
+        }
+    }
+
+    @objc private func audioRouteChanged(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue:reasonValue) else {
+            return
+        }
+
+        if reason == .oldDeviceUnavailable {
+            // audio output device was disconnected
+            // change output to speaker
+            isSpeaker = true
+        }
+    }
+
     private func updateCollectionViewLayout() {
         calculateCellSize()
         layout.itemSize = itemCellSize
@@ -113,6 +197,7 @@ class VideoMeetRoomViewController: UIViewController {
         screenShareViewController = nil
         participantsViewController = nil
         UIApplication.shared.isIdleTimerDisabled = false
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
     }
 
     // MARK: - Private methods
@@ -535,6 +620,7 @@ class VideoMeetRoomViewController: UIViewController {
             if status == .connected, let localParticipant = try? self.room.getLocalParticipant() {
                 self.visibleParticipants.insert(self.localParticipantId, at: 0)
                 DispatchQueue.main.async {
+                    self.configureAudio()
                     if !self.participantsList.contains(where: { $0.id == localParticipant.id }) {
                         self.participantsList.insert(localParticipant, at: 0)
                         self.allParticipantsList.insert(localParticipant, at: 0)

--- a/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
+++ b/Telnyx Meet/Controllers/VideoMeetRoomViewController.swift
@@ -196,6 +196,7 @@ class VideoMeetRoomViewController: UIViewController {
         refreshTokenTimer = nil
         screenShareViewController = nil
         participantsViewController = nil
+        localStream = nil
         UIApplication.shared.isIdleTimerDisabled = false
         NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
     }
@@ -242,20 +243,20 @@ class VideoMeetRoomViewController: UIViewController {
     }
 
     private func setupBackgroundFiltersMenu() {
-        let noFilter = UIAction(title: "No Filter", subtitle: "Removes the background filter.", image: nil) { (action) in
-            self.mediaDevices.cameraFilter = nil
+        let noFilter = UIAction(title: "No Filter", subtitle: "Removes the background filter.", image: nil) { [weak self] (action) in
+            self?.mediaDevices.cameraFilter = nil
         }
-        let blurFilter = UIAction(title: "Blur", subtitle: "Blurs the background.", image: nil) { (action) in
-            self.setBGBlurFilter()
+        let blurFilter = UIAction(title: "Blur", subtitle: "Blurs the background.", image: nil) { [weak self] (action) in
+            self?.setBGBlurFilter()
         }
-        let abstractFilter = UIAction(title: "Abstract", subtitle: "Applies abstract background.", image: nil) { (action) in
-            self.setVirtualBGFilter(imageName: "abstract")
+        let abstractFilter = UIAction(title: "Abstract", subtitle: "Applies abstract background.", image: nil) { [weak self] (action) in
+            self?.setVirtualBGFilter(imageName: "abstract")
         }
-        let wolverineFilter = UIAction(title: "Wolverine", subtitle: "Applies Wolverine background.", image: nil) { (action) in
-            self.setVirtualBGFilter(imageName: "wolverine")
+        let wolverineFilter = UIAction(title: "Wolverine", subtitle: "Applies Wolverine background.", image: nil) { [weak self] (action) in
+            self?.setVirtualBGFilter(imageName: "wolverine")
         }
-        let eiffelTowerFilter = UIAction(title: "Eiffel Tower", subtitle: "Applies Eiffel Tower background.", image: nil) { (action) in
-            self.setVirtualBGFilter(imageName: "eiffel tower")
+        let eiffelTowerFilter = UIAction(title: "Eiffel Tower", subtitle: "Applies Eiffel Tower background.", image: nil) { [weak self] (action) in
+            self?.setVirtualBGFilter(imageName: "eiffel tower")
         }
         let children = [
             noFilter,
@@ -1114,17 +1115,17 @@ class VideoMeetRoomViewController: UIViewController {
     }
     
     @IBAction private func onLeaveButton() {
+        self.mediaDevices.cameraFilter = nil
+        self.mediaDevices.stopCapturingCameraVideo()
         if self.room.status == .connected {
             self.room.disconnect { [weak self] in
                 guard let self = self else { return }
-                self.mediaDevices.stopCapturingCameraVideo()
                 DispatchQueue.main.async {
                     self.navigationController?.popViewController(animated: true)
                 }
             }
             return
         } else {
-            self.mediaDevices.stopCapturingCameraVideo()
             self.navigationController?.popViewController(animated: true)
         }
     }
@@ -1136,6 +1137,12 @@ class VideoMeetRoomViewController: UIViewController {
 
     @IBAction private func toggleVideo() {
         videoEnabled.toggle()
+        if videoEnabled {
+            mediaDevices.startCapturingCameraVideo()
+        } else {
+            mediaDevices.stopCapturingCameraVideo()
+        }
+        bgFiltersBtn.isEnabled = videoEnabled
         updateLocalStream(audio: audioEnabled, video: videoEnabled)
     }
 


### PR DESCRIPTION
**Before:**
After joining a room, the audio was always routed through the built-in receiver. There was not way to route the audio via speaker.

**After:**
In this PR, after joining a room, the audio is routed through speaker by default. There is also an airplay button on the navigation bar which allows the user to choose the audio output from the available devices.

**Screenshots:**
| Airplay Button | Output Devices |
| --- | --- |
| ![audio output btn](https://user-images.githubusercontent.com/14951672/173621326-c5eb8896-6bb6-412c-99ca-9ad5b7007c7a.PNG) | ![audio output popup](https://user-images.githubusercontent.com/14951672/173621286-338c10ec-028b-4bba-86e7-4a6f89063102.PNG) |
